### PR TITLE
Bind numpad "divide" to open console

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -410,6 +410,7 @@ enter={
 command={
 "deadzone": 0.5,
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":47,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777346,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
  ]
 }
 down={


### PR DESCRIPTION
Some non-US keyboards don't have "slash" key and the engine doesn't recognize key combinations that would normally type out `/`. This PR will enable players with full size keyboards to use number pad `/` (divide) as an alternative.