### PR TITLE
Fix artificial volcanoes not generating correctly with buildings 

### DIFF
--- a/Scripts/Game.gd
+++ b/Scripts/Game.gd
@@ -2809,7 +2809,7 @@ func generate_volcano(t_id:int, VEI:float, artificial:bool = false):
 					var diff = max(richness - current_tile.ash.richness, 0)
 					if current_tile.has("bldg"):
 						var rsrc = building_to_resource[current_tile.bldg.name]
-						if rsrc
+						if rsrc:
 						autocollect.rsrc[rsrc] += diff * current_tile.bldg.path_1_value * overclock_mult * current_tile.resource_production_bonus.get(rsrc, 1.0)
 					current_tile.ash.richness = max(richness, current_tile.ash.richness)
 					current_tile.resource_production_bonus.minerals = current_tile.resource_production_bonus.get("minerals", 1.0) + diff
@@ -2820,7 +2820,7 @@ func generate_volcano(t_id:int, VEI:float, artificial:bool = false):
 				current_tile.resource_production_bonus.SP = current_tile.resource_production_bonus.get("SP", 1.0) + (richness - 1.0) / 2.0
 				if current_tile.has("bldg"):
 						var rsrc = building_to_resource[current_tile.bldg.name]
-						if rsrc
+						if rsrc:
 							autocollect.rsrc[rsrc] += (richness - 1.0) * current_tile.bldg.path_1_value * overclock_mult * current_tile.resource_production_bonus.get(rsrc, 1.0)
 				if artificial:
 					current_tile.ash.artificial = true

--- a/Scripts/Game.gd
+++ b/Scripts/Game.gd
@@ -2807,9 +2807,8 @@ func generate_volcano(t_id:int, VEI:float, artificial:bool = false):
 			if current_tile.has("ash"):
 				if not current_tile.has("cave"):
 					var diff = max(richness - current_tile.ash.richness, 0)
-					if current_tile.has("bldg"):
+					if current_tile.has("bldg") and building_to_resource.has(current_tile.bldg.name):
 						var rsrc = building_to_resource[current_tile.bldg.name]
-						if rsrc:
 						autocollect.rsrc[rsrc] += diff * current_tile.bldg.path_1_value * overclock_mult * current_tile.resource_production_bonus.get(rsrc, 1.0)
 					current_tile.ash.richness = max(richness, current_tile.ash.richness)
 					current_tile.resource_production_bonus.minerals = current_tile.resource_production_bonus.get("minerals", 1.0) + diff
@@ -2818,10 +2817,9 @@ func generate_volcano(t_id:int, VEI:float, artificial:bool = false):
 				current_tile.ash = {"richness":richness}
 				current_tile.resource_production_bonus.minerals = current_tile.resource_production_bonus.get("minerals", 1.0) + (richness - 1.0)
 				current_tile.resource_production_bonus.SP = current_tile.resource_production_bonus.get("SP", 1.0) + (richness - 1.0) / 2.0
-				if current_tile.has("bldg"):
-						var rsrc = building_to_resource[current_tile.bldg.name]
-						if rsrc:
-							autocollect.rsrc[rsrc] += (richness - 1.0) * current_tile.bldg.path_1_value * overclock_mult * current_tile.resource_production_bonus.get(rsrc, 1.0)
+				if current_tile.has("bldg") and building_to_resource.has(current_tile.bldg.name):
+					var rsrc = building_to_resource[current_tile.bldg.name]
+					autocollect.rsrc[rsrc] += (richness - 1.0) * current_tile.bldg.path_1_value * overclock_mult * current_tile.resource_production_bonus.get(rsrc, 1.0)
 				if artificial:
 					current_tile.ash.artificial = true
 			if not achievement_data.exploration.has("volcano_cave") and current_tile.has("cave"):

--- a/Scripts/Game.gd
+++ b/Scripts/Game.gd
@@ -2809,6 +2809,7 @@ func generate_volcano(t_id:int, VEI:float, artificial:bool = false):
 					var diff = max(richness - current_tile.ash.richness, 0)
 					if current_tile.has("bldg"):
 						var rsrc = building_to_resource[current_tile.bldg.name]
+						if rsrc
 						autocollect.rsrc[rsrc] += diff * current_tile.bldg.path_1_value * overclock_mult * current_tile.resource_production_bonus.get(rsrc, 1.0)
 					current_tile.ash.richness = max(richness, current_tile.ash.richness)
 					current_tile.resource_production_bonus.minerals = current_tile.resource_production_bonus.get("minerals", 1.0) + diff
@@ -2819,7 +2820,8 @@ func generate_volcano(t_id:int, VEI:float, artificial:bool = false):
 				current_tile.resource_production_bonus.SP = current_tile.resource_production_bonus.get("SP", 1.0) + (richness - 1.0) / 2.0
 				if current_tile.has("bldg"):
 						var rsrc = building_to_resource[current_tile.bldg.name]
-						autocollect.rsrc[rsrc] += (richness - 1.0) * current_tile.bldg.path_1_value * overclock_mult * current_tile.resource_production_bonus.get(rsrc, 1.0)
+						if rsrc
+							autocollect.rsrc[rsrc] += (richness - 1.0) * current_tile.bldg.path_1_value * overclock_mult * current_tile.resource_production_bonus.get(rsrc, 1.0)
 				if artificial:
 					current_tile.ash.artificial = true
 			if not achievement_data.exploration.has("volcano_cave") and current_tile.has("cave"):


### PR DESCRIPTION
OK, finally fixed.

Volcano gen would stop when encountering a building it had no effect on. Now it just skips it and continues generating.