### PR TITLE
Fixed build mode right click exit and added new commands

### DIFF
--- a/Scripts/Game.gd
+++ b/Scripts/Game.gd
@@ -257,6 +257,8 @@ var cave_filters = {
 	"stone":false,
 }
 
+var are_costs_zero:bool = false
+
 # Stores the locations of all boring machines the player has built
 # to make autocollecting metals possible while minimizing lag
 var boring_machine_data = {
@@ -3760,6 +3762,8 @@ func get_star_class (temp):
 
 #Checks if player has enough resources to buy/craft/build something
 func check_enough(costs):
+	if are_costs_zero:
+		return true
 	var enough = true
 	for cost in costs:
 		if cost == "money" and money < costs[cost]:
@@ -3779,6 +3783,8 @@ func check_enough(costs):
 	return true
 
 func deduct_resources(costs):
+	if are_costs_zero:
+		return
 	for cost in costs:
 		if cost == "money":
 			money -= costs.money
@@ -4699,6 +4705,7 @@ func _on_PanelAnimationPlayer_animation_finished(anim_name):
 		$UI/Panel.visible = false
 
 
+
 func _on_command_text_submitted(new_text):
 	cmd_node.visible = false
 	cmd_history_index = -1
@@ -4780,6 +4787,17 @@ func _on_command_text_submitted(new_text):
 		"unlockbldgs":
 			for i in len(Building.names):
 				new_bldgs[i] = true
+		"zerocosts":
+			if len(arr) > 1:
+				if arr[1] == "true" or arr[1] == "1":
+					are_costs_zero = true
+				elif arr[1] == "false" or arr[1] == "0":
+					are_costs_zero = false
+				else:
+					popup("Invalid argument. Use 'true' or 'false'", 2)
+					return
+			else:
+				are_costs_zero = not are_costs_zero
 		_:
 			fail = true
 	if not fail:

--- a/Scripts/Planet.gd
+++ b/Scripts/Planet.gd
@@ -1039,6 +1039,10 @@ func _unhandled_input(event):
 	var mass_build:bool = Input.is_action_pressed("left_click") and Input.is_action_pressed("shift") and game.bottom_info_action == "building" and constructing_ancient_building_tier == -1
 	view.move_view = not mass_build
 	view.scroll_view = not mass_build
+	# Right-click to exit build mode
+	if game.bottom_info_action == "building" and Input.is_action_just_pressed("right_click"):
+		game._on_BottomInfo_close_button_pressed()
+		return
 	if tile_over != -1 and game.bottom_info_action != "building" and tile_over < len(game.tile_data):
 		var tile = game.tile_data[tile_over]
 		if tile:

--- a/commands.txt
+++ b/commands.txt
@@ -83,3 +83,10 @@ Commands list:
 - Possible values of [ship ID]: 0, 1, 2, 3
 - Possible values of [XP type]: xp, bullet, laser, bomb, light
 - Example: `/addshipxp 1 laser 300
+
+/zerocosts [true/false/1/0]
+- Toggles or sets whether all resource costs are ignored
+- Without arguments, toggles the state on/off
+- With arguments, sets to true/1 (ignore costs) or false/0 (restore costs)
+- When enabled, all purchases (buildings, ancient buildings, megastructures, rover parts, upgrades, science, etc.) will not check or deduct resources
+- Example: /zerocosts true or /zerocosts 1 (enable), /zerocosts false or /zerocosts 0 (disable)


### PR DESCRIPTION
Fixed build mode exit when exiting via right-click or Esc. Added /zerocosts and /costs commands to set all building costs to zero and restore them. Updated command documentation.